### PR TITLE
Fix build on XCode 12.1  (tested on bigsur only)

### DIFF
--- a/MonitorDataSource.m
+++ b/MonitorDataSource.m
@@ -22,6 +22,8 @@
 #import "DisplayIDAndNameCondition.h"
 #import "ResolutionDataSource.h"
 #include <stdlib.h>
+#include "DisplayData.h"
+
 
 @implementation MonitorDataSource
 @synthesize display;


### PR DESCRIPTION
Just tried to compile this on bigsur with xcode 12.1; had to include the header file to avoid the compiler from complaining about missing symbols due to C99